### PR TITLE
Fix 2html.vim error

### DIFF
--- a/tohtml.sh
+++ b/tohtml.sh
@@ -42,7 +42,7 @@ vim --noplugin -u NONE \
   -c ":set nocp" \
   -c ":source ${tools}" \
   -c ":set bg=light" \
-  -c ":colorscheme wildcharm" \
+  -c ":colorscheme default" \
   -c ":call IndentPlantUML('$1')" \
   -c ":let g:loaded_2html_plugin = 0" \
   -c ":source $toHtml" \


### PR DESCRIPTION
I'm getting an error in 2html.vim when I use "wildcharm" for colorshceme, so why don't you change it back to "default"?

![DIB BITMAP](https://github.com/user-attachments/assets/5d637184-28cd-44dc-a2b3-66e162348ad2)


And the version of Vim used by Github Actions does not seem to have "wildcharm" in it yet.

![image](https://github.com/user-attachments/assets/7deef489-86f7-4c3b-8ad1-5e245af95470)
